### PR TITLE
Standardize naming convention across README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,16 +154,16 @@ Tahoe-x1 models are trained on large-scale single-cell RNA-seq datasets. The fol
 
 | Dataset | Description | Usage | Location |
 |---------|-------------|-------|----------|
-| **CellxGene 2025-01** | ~61M  cells  from Jan 2025 CellxGene release | Tx1-3b stage 1 Pre-training  | `s3://tahoe-hackathon-data/MFM/cellxgene_2025_01_21_merged_MDS/` |
-| **scBaseCamp 2025-02** | ~112M  cells from Feb 2025 scBaseCamp release | Tx1-3b stage 1 Pre-training | `s3://tahoe-hackathon-data/MFM/scbasecamp_2025_02_25_MDS_v2/` |
-| **Tahoe 100M** | ~96M  cells from Tahoe-100M | Tx1-3b stage 1 Pre-training | `s3://tahoe-hackathon-data/MFM/tahoe_100m_MDS_v2/` |
-| **filtered CellxGene 2025-01** | ~43M filtered cells  from Jan 2025 CellxGene release | Tx1-3b stage 2 Pre-training  | `s3://tahoe-hackathon-data/MFM/cellxgene_2025_01_21_merged_MDS_filtered/` |
-| **filtered scBaseCamp 2025-02** | ~76M filtered cells from Feb 2025 scBaseCamp release | Tx1-3b stage 2 Pre-training | `s3://tahoe-hackathon-data/MFM/scbasecamp_2025_02_25_MDS_v2_filtered/` |
-| **filtered Tahoe 100M** | ~34M filtered cells from Tahoe-100M | Tx1-3b stage 2 Pre-training | `s3://tahoe-hackathon-data/MFM/tahoe_100m_MDS_v2_filtered/` |
+| **CellxGene 2025-01** | ~61M  cells  from Jan 2025 CellxGene release | Tx1-3B stage 1 Pre-training  | `s3://tahoe-hackathon-data/MFM/cellxgene_2025_01_21_merged_MDS/` |
+| **scBaseCamp 2025-02** | ~112M  cells from Feb 2025 scBaseCamp release | Tx1-3B stage 1 Pre-training | `s3://tahoe-hackathon-data/MFM/scbasecamp_2025_02_25_MDS_v2/` |
+| **Tahoe 100M** | ~96M  cells from Tahoe-100M | Tx1-3B stage 1 Pre-training | `s3://tahoe-hackathon-data/MFM/tahoe_100m_MDS_v2/` |
+| **filtered CellxGene 2025-01** | ~43M filtered cells  from Jan 2025 CellxGene release | Tx1-3B stage 2 Pre-training  | `s3://tahoe-hackathon-data/MFM/cellxgene_2025_01_21_merged_MDS_filtered/` |
+| **filtered scBaseCamp 2025-02** | ~76M filtered cells from Feb 2025 scBaseCamp release | Tx1-3B stage 2 Pre-training | `s3://tahoe-hackathon-data/MFM/scbasecamp_2025_02_25_MDS_v2_filtered/` |
+| **filtered Tahoe 100M** | ~34M filtered cells from Tahoe-100M | Tx1-3B stage 2 Pre-training | `s3://tahoe-hackathon-data/MFM/tahoe_100m_MDS_v2_filtered/` |
 | **DepMap** | Cancer cell line dependency data | DepMap Benchmark | `s3://tahoe-hackathon-data/MFM/benchmarks/depmap/` |
 | **MSigDB** | Pathway signature data | MsigDB Benchmark | `s3://tahoe-hackathon-data/MFM/benchmarks/msigdb/` |
 
-Filtered versions of the pre-training datasets above exclude cells with very few expressed genes and are used for stage 2 pre-training of Tx1-3b.
+Filtered versions of the pre-training datasets above exclude cells with very few expressed genes and are used for stage 2 pre-training of Tx1-3B.
 
 Public access to datasets: `s3://tahoe-hackathon-data/MFM/benchmarks/`
 
@@ -179,9 +179,9 @@ We provide pre-trained Tahoe-x1 models of various sizes:
 
 | Model Name | Parameters | Context Length | Checkpoint Path | WandB ID | Config File |
 |------------|------------|----------------|-----------------|----------|-------------|
-| **TX1-3B** | 3B | 2056  | `s3://tahoe-hackathon-data/MFM/ckpts/3b/` | [mygjkq5c](https://wandb.ai/vevotx/tahoe-x1/runs/mygjkq5c) | `./configs/mcli/tahoex-3b-v2-cont-train.yaml` |
-| **TX1-1.3B** | 1.3B | 2048 | `s3://tahoe-hackathon-data/MFM/ckpts/1b/` | [26iormxc](https://wandb.ai/vevotx/tahoe-x1/runs/26iormxc) | `./configs/gcloud/tahoex-1_3b-merged.yaml` |
-| **TX1-70M** | 70M | 1024 | `s3://tahoe-hackathon-data/MFM/ckpts/70m/` | [ftb65le8](https://wandb.ai/vevotx/tahoe-x1/runs/ftb65le8) | `./configs/gcloud/tahoex-70m-merged.yaml` |
+| **Tx1-3B** | 3B | 2056  | `s3://tahoe-hackathon-data/MFM/ckpts/3b/` | [mygjkq5c](https://wandb.ai/vevotx/tahoe-x1/runs/mygjkq5c) | `./configs/mcli/tahoex-3b-v2-cont-train.yaml` |
+| **Tx1-1.3B** | 1.3B | 2048 | `s3://tahoe-hackathon-data/MFM/ckpts/1b/` | [26iormxc](https://wandb.ai/vevotx/tahoe-x1/runs/26iormxc) | `./configs/gcloud/tahoex-1_3b-merged.yaml` |
+| **Tx1-70M** | 70M | 1024 | `s3://tahoe-hackathon-data/MFM/ckpts/70m/` | [ftb65le8](https://wandb.ai/vevotx/tahoe-x1/runs/ftb65le8) | `./configs/gcloud/tahoex-70m-merged.yaml` |
 
 Models are also available on HuggingFace: `tahoebio/TahoeX1`
 
@@ -207,7 +207,7 @@ composer scripts/train.py \
   --batch_size 32
 ```
 
-Note that the current codebase only supports `attn_impl: flash` and `use_attn_mask: False`. The Triton backend and custom attention masks (used for training TX1-1B and TX1-70M) are no longer supported. If you have questions about using custom attention masks with the Triton backend, please contact us.
+Note that the current codebase only supports `attn_impl: flash` and `use_attn_mask: False`. The Triton backend and custom attention masks (used for training Tx1-1B and Tx1-70M) are no longer supported. If you have questions about using custom attention masks with the Triton backend, please contact us.
 
 ### Fine-tuning
 

--- a/configs/gcloud/README.md
+++ b/configs/gcloud/README.md
@@ -1,4 +1,4 @@
-# Launching a TahoeX run on Google Cloud
+# Launching a Tahoe-x1 run on Google Cloud
 
 DWS can be used either through Google Kubernetes Engine (GKE) or through MIG resize requests. Although the process with GKE would be more automated and require fewer manual steps (such as launching the launcher individually on each node) 
 I was not able to get it to work. The initial steps for setting up GKE can be found [here](https://cloud.google.com/kubernetes-engine/docs/how-to/provisioningrequest). The provisioning-request and job-spec created for this process are included in this folder. 

--- a/scripts/data_prep/README.md
+++ b/scripts/data_prep/README.md
@@ -1,6 +1,6 @@
 # v2 Dataset Preparation Scripts
 
-This folder contains scripts for the first major update to the pretraining dataset for TahoeX.
+This folder contains scripts for the first major update to the pretraining dataset for Tahoe-x1.
 This release includes data from CellXGene (~60M cells), scBasecamp (~115M cells) as well as Vevo's Tahoe-100M dataset (~96M).
 
 | Dataset                             | Description                                                                                                               | s3 path                                                               |

--- a/scripts/depmap/README.md
+++ b/scripts/depmap/README.md
@@ -1,6 +1,6 @@
 # DepMap benchmarks
 
-This folder contains the scripts required to evaluate TahoeX on three benchmarks centered around the DepMap dataset.
+This folder contains the scripts required to evaluate Tahoe-x1 on three benchmarks centered around the DepMap dataset.
 
 1. separate cancer cell lines by tissue of origin.
 2. predict whether genes are broadly essential or inessential.
@@ -43,12 +43,12 @@ This S3 bucket is populated with embeddings and results from the following model
 - TranscriptFormer (Exemplar)
 - TranscriptFormer (Metazoa)
 - STATE
-- TahoeX (~70M parameters)
-- TahoeX (~1.3B parameters)
-- TahoeX (~3B parameters)
-- TahoeX (~3B parameters, training continued with alternate gene encoder)
+- Tx1 (~70M parameters)
+- Tx1 (~1.3B parameters)
+- Tx1 (~3B parameters)
+- Tx1 (~3B parameters, training continued with alternate gene encoder)
 
-For more details on how we retrieved embeddings from non-TahoeX models, please see `other-models.md` in this repository.
+For more details on how we retrieved embeddings from non-Tx1 models, please see `other-models.md` in this repository.
 
 **If you sync the entire directory (415GB), you can skip to step 4 and start evaluating new models.**
 
@@ -109,11 +109,11 @@ python generate-nulls.py --base-path [path]
 
 ### Step 4: generate embeddings for the model being evaluated
 
-When you have a new TahoeX model to evaluate, use `generate-embs-model.py` to extract the embeddings needed for the DepMap benchmarks. Note that in all the following examples, the model name is something you can choose. File names are based this parameter, and you'll use it in steps 5 and 6. For the most seamless operation, specify the model name with nothing but hyphens. In step 5, and for task #2 and task #3 in step 6, the hyphens will be replaced with underscores.
+When you have a new Tx1 model to evaluate, use `generate-embs-model.py` to extract the embeddings needed for the DepMap benchmarks. Note that in all the following examples, the model name is something you can choose. File names are based this parameter, and you'll use it in steps 5 and 6. For the most seamless operation, specify the model name with nothing but hyphens. In step 5, and for task #2 and task #3 in step 6, the hyphens will be replaced with underscores.
 
 ```
-model name: TahoeX-70m-verify-script
-downstream: TahoeX_70m_verify_script
+model name: Tx1-70m-verify-script
+downstream: Tx1_70m_verify_script
 ```
 
 To run the script, you'll need a directory containing `best-model.pt`, `collator_config.yml`, `model_config.yml`, and `vocab.json`. Pass the location of this directory to the script using the `--model-path` argument.
@@ -142,25 +142,25 @@ Use `rf-cl-specific-task-[1,2,3]of3.sh` for task #3. The three scripts are inten
 bash rf-cl-specific-task-[1,2,3]of3.sh [base folder path] [embedding name, usually model name with underscores] [number of cores to use, 16-32 is usually good]
 ```
 
-#### Note on non-TahoeX models
+#### Note on non-Tx1 models
 
-Due to differing vocabularies and context size limits, the various non-TahoeX models we provide results for (see Step 0) have different numbers of genes with available embeddings. Below is a table summarizing this information.
+Due to differing vocabularies and context size limits, the various non-Tx1 models we provide results for (see Step 0) have different numbers of genes with available embeddings. Below is a table summarizing this information.
 
 | model | number of available genes |
 |---|---|
-| TahoeX | 14,283 |
+| Tx1 | 14,283 |
 | Geneformer | 11,448 |
 | scGPT | 14,285 |
 | TranscriptFormer | 1,892 |
 | STATE | 9,516 |
 
-You can use the `--filter-genes` argument in `rf.py` to restrict the embeddings being evaluated to a set of genes taken from another model. Use this in conjunction with the `--add-label` argument to keep track of which results are generated from which gene sets. Here is an example for running the first fold of task #2 on embeddings from TahoeX-70M restricted to STATE genes.
+You can use the `--filter-genes` argument in `rf.py` to restrict the embeddings being evaluated to a set of genes taken from another model. Use this in conjunction with the `--add-label` argument to keep track of which results are generated from which gene sets. Here is an example for running the first fold of task #2 on embeddings from Tx1-70M restricted to STATE genes.
 
 ```
-python rf.py --base-path <path to base folder> --model-type classifier --emb tahoex_70m-mean-lt5gt70-bin --filter-genes state-mean-lt5gt70-bin --split-file split-genes-lt5gt70.csv --split-col gene --n-jobs 8 --fold 0 --add-label="-state-genes"
+python rf.py --base-path <path to base folder> --model-type classifier --emb tx1_70m-mean-lt5gt70-bin --filter-genes state-mean-lt5gt70-bin --split-file split-genes-lt5gt70.csv --split-col gene --n-jobs 8 --fold 0 --add-label="-state-genes"
 ```
 
-You would then use `tahoex_70m-mean-lt5gt70-bin-state-genes` to refer to these results downstream.
+You would then use `tx1_70m-mean-lt5gt70-bin-state-genes` to refer to these results downstream.
 
 ---
 


### PR DESCRIPTION
- Changed TX1-* to Tx1-* for model names (Tx1-3B, Tx1-1.3B, Tx1-70M)
- Changed TahoeX to Tahoe-x1 for project references
- Changed tahoex_* to tx1_* in code examples for consistency
- Kept tahoex as-is for actual file/variable names