### PR TITLE
Update README.md to fix shared memory exhaustion within docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ composer scripts/train.py \
   model.d_model=512 \
   model.n_layers=12 \
   train_loader.num_workers=8 \
-  max_duration=6ep
+  max_duration=1000ba
 ```
 
 ## System Requirements & Training Capabilities


### PR DESCRIPTION
This PR updates the Docker run configuration and related documentation to fix shared memory exhaustion errors encountered during model training.
PyTorch’s DataLoader previously crashed with Bus error / No space left on device due to Docker’s default /dev/shm limit (64 MB).