### PR TITLE
added weights_only=False flag to load_model

### DIFF
--- a/tahoe_x1/utils/util.py
+++ b/tahoe_x1/utils/util.py
@@ -60,7 +60,10 @@ def load_model(
         model_config=model_config,
         collator_config=collator_config,
     )
-    model.load_state_dict(torch.load(ckpt, weights_only=False)["state"]["model"], strict=strict)
+    model.load_state_dict(
+        torch.load(ckpt, weights_only=False)["state"]["model"],
+        strict=strict,
+    )
     model.to(device)
     model.eval()
     log.info(f"Model loaded from {ckpt}")


### PR DESCRIPTION
pytorch 2.6 weights_only default value is changed to True which breaks the load_model default behavior. Explicitly setting the flag to False ensure same behavior