### PR TITLE
fixed issue #69

### DIFF
--- a/scripts/inference/configs/predict.yaml
+++ b/scripts/inference/configs/predict.yaml
@@ -1,5 +1,7 @@
 paths:
-  model_dir: "/tahoe/data/ckpts/tx/release/tahoe_x1-70m-VQ9aRB"
+  # model_dir: "/tahoe/data/ckpts/TahoeX1/mosaicfm-70m-merged"
+  hf_repo_id: "tahoebio/Tahoe-x1"
+  hf_model_size: "70m"
   adata_input: "/tahoe/data/datasets/benchmark/kim2020_lung/kim_test.h5ad" #"/tahoe/data/datasets/benchmark/CCLE/ccle.h5ad" # "/tahoe/data/datasets/benchmark/tahoe/Tahoe50k_train.h5ad"
   adata_output: "./pred_adata.h5ad"
   drug_to_id_path: "drug_to_id_pad.json"
@@ -14,5 +16,5 @@ predict:
   seq_len_dataset: 2048 #8192
   num_workers: 8
   prefetch_factor: 48 #2
-  return_gene_embeddings: True  # Whether to extract gene embeddings
+  return_gene_embeddings: False  # Whether to extract gene embeddings
   use_chem_inf: False  # Whether to use chemical information for prediction if the model is trained with chemical information

--- a/scripts/inference/predict_embeddings.py
+++ b/scripts/inference/predict_embeddings.py
@@ -69,6 +69,7 @@ def predict_embeddings(cfg: DictConfig) -> None:
         model, vocab, _, coll_cfg = ComposerTX.from_hf(
             hf_repo_id,
             hf_model_size,
+            return_gene_embeddings=return_gene_embeddings,
         )
     print(f"Model is loaded with {model.model.n_layers} transformer layers.")
 

--- a/tahoe_x1/model/model.py
+++ b/tahoe_x1/model/model.py
@@ -425,8 +425,8 @@ class ComposerTX(ComposerModel):
         cls,
         repo_id: str,
         model_size: str,
-        return_gene_embeddings: Optional[bool] = False,
-        use_chem_inf: Optional[bool] = False,
+        return_gene_embeddings: bool = False,
+        use_chem_inf: bool = False,
     ):
 
         # helper function to download files

--- a/tahoe_x1/model/model.py
+++ b/tahoe_x1/model/model.py
@@ -425,7 +425,7 @@ class ComposerTX(ComposerModel):
         cls,
         repo_id: str,
         model_size: str,
-        return_gene_embeddings: bool = True,
+        return_gene_embeddings: Optional[bool] = False,
         use_chem_inf: Optional[bool] = False,
     ):
 


### PR DESCRIPTION
This PR fixes #69 raised by community.
The` return_gene_embeddings` parameter is now set to False by default in `from_hf`.
Additionally, the model loading logic in `predict_embeddings.py` (via `from_hf`) has been updated to accept the `return_gene_embeddings` from the config file.

`        model, vocab, _, coll_cfg = ComposerTX.from_hf(
            hf_repo_id,
            hf_model_size,
            return_gene_embeddings=return_gene_embeddings,
        )`