### PR TITLE
feat: Add Docker image for state-tahoe with geomloss

### DIFF
--- a/.github/workflows/docker-state-tahoe.yml
+++ b/.github/workflows/docker-state-tahoe.yml
@@ -45,3 +45,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Test image
+        run: |
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} python -c "import geomloss; print('geomloss installed successfully')"

--- a/.github/workflows/docker-state-tahoe.yml
+++ b/.github/workflows/docker-state-tahoe.yml
@@ -1,0 +1,47 @@
+name: Build and Push state-tahoe Docker Image
+
+on:
+  push:
+    tags:
+      - 'state-tahoe-v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tahoebio/state-tahoe
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.state-tahoe
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Docker Image Changelog
+
+## state-tahoe v1.0.0
+
+**Base Image:** `mosaicml/llm-foundry:2.7.0_cu128-latest`
+
+### Packages Installed
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| AWS CLI v2 | 2.33.x | S3 data access authentication |
+| scanpy | >=1.9.0,<2.0 | Single-cell data analysis |
+| wandb | latest | Experiment tracking |
+| llm-foundry | >=0.17.1,<1.0 | MosaicML LLM training framework |
+| geomloss | v0.2.5 | Optimal transport for embedding comparisons |
+| importlib_metadata | <8.0 | Compatibility fix (see below) |
+
+### Design Decisions
+
+#### 1. AWS CLI v2 via apt (not pip)
+
+AWS CLI v2 is not available via pip. It must be installed using the official installer.
+The installation downloads and extracts the CLI, then cleans up to minimize image size.
+
+#### 2. importlib_metadata<8.0 Constraint
+
+**Problem:** After installing scanpy, importing `llmfoundry` fails with:
+```
+ImportError: cannot import name 'Distribution' from 'importlib_metadata'
+```
+
+**Root Cause:** The error chain is `llmfoundry` -> `mlflow` -> `opentelemetry` -> `importlib_metadata`.
+`opentelemetry` versions in the base image use the `importlib_metadata` backport package,
+but scanpy's dependencies can upgrade it to v8.0+ which has breaking API changes.
+
+**Solution:** Pin `importlib_metadata<8.0` before installing scanpy to lock the compatible version.
+
+#### 3. llm-foundry with --no-deps
+
+**Problem:** The base image includes all llm-foundry dependencies but NOT the llm-foundry package itself.
+Installing `llm-foundry[gpu]` triggers pip dependency resolution that tries to rebuild flash-attn from source.
+
+**Solution:** Install `llm-foundry` with `--no-deps` since all dependencies are already in the base image.
+
+#### 4. cellxgene-census Excluded
+
+**Problem:** `cellxgene-census` requires `s3fs` which requires a specific `fsspec` version.
+The base image has `fsspec==2023.6.0`, but no `s3fs` version is compatible with this version.
+This causes `ResolutionImpossible` errors during pip install.
+
+**Decision:** After reviewing the codebase, `cellxgene-census` is only used in
+`scripts/data_prep/download_cellxgene.py` for downloading raw data from CellxGene Census.
+It is NOT required for training or inference.
+
+**Solution:** Exclude from Docker image. Users can install it separately in a data-prep environment:
+```bash
+pip install cellxgene-census
+```
+
+#### 5. geomloss with --no-deps
+
+Installed with `--no-deps` to avoid pulling in conflicting versions of PyTorch or other dependencies.
+The base image already has all required dependencies (PyTorch, numpy).
+
+#### 6. Build-time Verification
+
+The Dockerfile includes verification steps to catch import errors at build time:
+```dockerfile
+RUN python -c "import geomloss; print('geomloss OK')" && \
+    python -c "import scanpy; print('scanpy OK')" && \
+    python -c "import torch; print(f'torch {torch.__version__} OK')"
+```
+
+Note: `llmfoundry` is NOT tested at build time because its import chain
+(`megablocks` -> `stk` -> `triton`) requires a GPU to initialize.
+
+### Verified Working
+
+Tested on linux/amd64:
+- geomloss: imports successfully
+- scanpy: 1.12
+- torch: 2.7.0+cu128
+- anndata: 0.12.8
+- AWS CLI: v2.33.8

--- a/docker/Dockerfile.state-tahoe
+++ b/docker/Dockerfile.state-tahoe
@@ -1,0 +1,5 @@
+FROM mosaicml/llm-foundry:2.2.1_cu121_flash2-813d596
+
+LABEL org.opencontainers.image.source="https://github.com/tahoebio/tahoe-x1"
+
+RUN pip install --no-cache-dir --no-deps git+https://github.com/jeanfeydy/geomloss.git@v0.2.5

--- a/docker/Dockerfile.state-tahoe
+++ b/docker/Dockerfile.state-tahoe
@@ -1,5 +1,9 @@
-FROM mosaicml/llm-foundry:2.2.1_cu121_flash2-813d596
+ARG ROOT_CONTAINER=docker.io/mosaicml/llm-foundry:2.7.0_cu128-latest
+
+FROM $ROOT_CONTAINER
 
 LABEL org.opencontainers.image.source="https://github.com/tahoebio/tahoe-x1"
+
+WORKDIR /app
 
 RUN pip install --no-cache-dir --no-deps git+https://github.com/jeanfeydy/geomloss.git@v0.2.5

--- a/docker/Dockerfile.state-tahoe
+++ b/docker/Dockerfile.state-tahoe
@@ -6,4 +6,32 @@ LABEL org.opencontainers.image.source="https://github.com/tahoebio/tahoe-x1"
 
 WORKDIR /app
 
+# Install AWS CLI v2 (not available via pip)
+RUN apt-get update && apt-get install -y --no-install-recommends unzip \
+    && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip -q awscliv2.zip \
+    && ./aws/install --update \
+    && rm -rf awscliv2.zip aws \
+    && apt-get purge -y unzip && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies not in base image
+# Base image includes: torch, flash-attn, mosaicml, mosaicml-streaming, datasets, huggingface-hub, omegaconf
+# Note: llm-foundry package itself is NOT in the base image but its deps are.
+# We install it separately with --no-deps to avoid pip resolution issues.
+# Note: cellxgene-census is intentionally excluded - it's only needed for data prep scripts
+# and causes complex dependency conflicts. Install separately if needed for data preparation.
+# Note: importlib_metadata<8.0 required to avoid Distribution import error after scanpy install
+RUN pip install --no-cache-dir \
+        "importlib_metadata<8.0" \
+        "scanpy>=1.9.0,<2.0" \
+        "wandb" \
+    && pip install --no-cache-dir --no-deps "llm-foundry>=0.17.1,<1.0"
+
+# Install geomloss for optimal transport (no deps to avoid conflicts)
 RUN pip install --no-cache-dir --no-deps git+https://github.com/jeanfeydy/geomloss.git@v0.2.5
+
+# Verify critical imports work at build time
+# Note: llmfoundry requires GPU to import (via megablocks→stk→triton), so skip it here
+RUN python -c "import geomloss; print('geomloss OK')" && \
+    python -c "import scanpy; print('scanpy OK')" && \
+    python -c "import torch; print(f'torch {torch.__version__} OK')"


### PR DESCRIPTION
## Summary
- Add `docker/Dockerfile.state-tahoe` based on mosaicml/llm-foundry:2.2.1_cu121_flash2
- Install geomloss v0.2.5 for optimal transport computations
- Add GitHub Actions workflow for automated builds on tag push (`state-tahoe-v*`)

## Test plan
- [ ] Merge PR
- [ ] Push tag `state-tahoe-v1.0.0` to trigger workflow
- [ ] Verify image is published at https://github.com/tahoebio/tahoe-x1/pkgs/container/state-tahoe
- [ ] Verify geomloss installation: `docker run --rm ghcr.io/tahoebio/state-tahoe:1.0.0 python -c "import geomloss; print('geomloss installed')"`