### PR TITLE
adds shield for bio.rodeo openness

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
         <img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-green.svg">
     </a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+<a href="https://bio.rodeo/models/tahoe-x1"><img alt="bio.rodeo openness score" src="https://img.shields.io/endpoint?url=https://bio.rodeo/api/badge/openness/tahoe-x1"></a>
 </p>
 <br />
 


### PR DESCRIPTION
Hi folks! 

A belated congratulations on the Tahoe-x1 release, and thank you for shipping the training recipe alongside the weights.

This PR adds a single line to your existing badge row:

```
<a href="https://bio.rodeo/models/tahoe-x1"><img alt="bio.rodeo openness score" src="https://img.shields.io/endpoint?url=https://bio.rodeo/api/badge/openness/tahoe-x1"></a>
```

**What [bio.rodeo](https://bio.rodeo) is:** An independent, open catalog of biological foundation models... approx 1,800 and growing as I backfill preprints and monitor new releases, from AlphaFold to single-cell models like yours. Every entry gets an openness score out of 100, built from the Model Openness Framework (https://arxiv.org/abs/2403.13784)'s 17 release components: weights, code, training data, documentation, and the licence attached to each. It measures what is actually released rather than whether something is called open.

**Where Tahoe-x1 lands:** 95/100 — the top 2% of the 1,817 models we've scored, where the median is 41. The reproducibility axis is the striking part: 92, against a catalog median of 29, with only 23 models scoring higher. Publishing the data and the recipe, not just the checkpoint, is rare enough that the score really does single you out. See https://bio.rodeo/leaderboard

The badge reads live from the API, so it stays current on its own. Full breakdown of tahoe-x1: https://bio.rodeo/models/tahoe-x1#openness

*Full disclosure: I maintain bio.rodeo and would obviously love for this PR to land. But absolutely no hard feelings if you'd rather not have another badge in your README, feel free to close this PR. And if anything in the assessment looks wrong, I'd genuinely like to hear it; there's a "Flag content" link on the model page, or just reply here.*

Thanks again for making the whole thing open. 🙏